### PR TITLE
Replace diagonal for loop with arma commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-SET(CMAKE_CXX_FLAGS "-std=c++14 -Wall -O3 -Wextra -Werror -Wno-unused")
+SET(CMAKE_CXX_FLAGS "-std=c++1z -Wall -O3 -Wextra -Werror -Wno-unused")
 if (OPENMP_FOUND)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")

--- a/include/local_lagrange/local_lagrange.h
+++ b/include/local_lagrange/local_lagrange.h
@@ -78,8 +78,9 @@ public:
     double result = 0.0;
     const size_t num_centers = centers_.n_rows;
     for (size_t i = 0; i < num_centers; ++i) {
-      const arma::rowvec::fixed<Dimension> diff = centers_.row(i) - point;
-      const double distance = arma::dot(diff, diff);
+
+      const double distance =
+          mathtools::computeSquaredDistance<Dimension>(centers_.row(i), point);
 
       // Safety check for distance = 0
       if (distance != 0.0) {

--- a/include/local_lagrange/local_lagrange.h
+++ b/include/local_lagrange/local_lagrange.h
@@ -25,7 +25,7 @@ public:
   arma::mat assembleInterpolationMatrix(const arma::mat &local_centers) {
     // Initialize matrix to all zeros.
 
-    size_t n_rows = local_centers.n_rows;
+    const size_t n_rows = local_centers.n_rows;
     arma::mat interp_matrix(n_rows + 3, n_rows + 3, arma::fill::zeros);
     double dist = 0.0;
     size_t num_centers = local_centers.n_rows;
@@ -55,7 +55,7 @@ public:
                          unsigned int local_index) {
     // Work needed here perhaps. Is this bad generating interp_matrix in this
     // function?
-    arma::mat interp_matrix = assembleInterpolationMatrix(local_centers);
+    const arma::mat interp_matrix = assembleInterpolationMatrix(local_centers);
     arma::vec rhs(local_centers.n_rows + 3, arma::fill::zeros);
     rhs(local_index) = 1;
     coefficients_ = arma::solve(interp_matrix, rhs);
@@ -85,6 +85,8 @@ public:
       // Safety check for distance = 0
       if (distance != 0.0) {
 
+        ///@todo srowe: Make the Kernel a parameter
+
         //.5 r^2 log(r^2) = r^2 log(r), this way we don't need square root
         ///@todo srowe: Would it be faster to convert this to std::log1p and use
         /// a conversion factor?
@@ -98,6 +100,7 @@ public:
     // form 1 + x + y
     const auto n_rows = coefficients_.n_rows;
 
+    ///@todo srowe: Make the polynomials more generic 
     ///@todo srowe: Those constant values are incorrect for dimension != 2
     double polynomial_term =
         coefficients_(n_rows - 3) +

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -11,6 +11,29 @@
 
 namespace mathtools {
 
+template <size_t Dimension, size_t Coordinate>
+inline double computeLengthSquared(const arma::rowvec::fixed<Dimension>& v) {
+  if constexpr (Coordinate == 0) {
+    return v(0)*v(0);
+  }
+  else {
+    return v(Coordinate)*v(Coordinate) + computeLengthSquared<Dimension, Coordinate-1>(v);
+ }
+}
+
+template <size_t Dimension>
+inline double computeLengthSquared(const arma::rowvec::fixed<Dimension>& v) {
+  if constexpr (Dimension > 1) {
+    return computeLengthSquared<Dimension, Dimension-1>(v);
+  }
+  else {
+    return v(0)*v(0);
+  }
+}
+
+
+
+
 template <size_t Coordinate>
 inline double computeDistance(const size_t row, const size_t col,
                               const arma::mat &points) {

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -12,27 +12,23 @@
 namespace mathtools {
 
 template <size_t Dimension, size_t Coordinate>
-inline double computeLengthSquared(const arma::rowvec::fixed<Dimension>& v) {
+inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   if constexpr (Coordinate == 0) {
-    return v(0)*v(0);
+    return v(0) * v(0);
+  } else {
+    return v(Coordinate) * v(Coordinate) +
+           computeLengthSquared<Dimension, Coordinate - 1>(v);
   }
-  else {
-    return v(Coordinate)*v(Coordinate) + computeLengthSquared<Dimension, Coordinate-1>(v);
- }
 }
 
 template <size_t Dimension>
-inline double computeLengthSquared(const arma::rowvec::fixed<Dimension>& v) {
+inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   if constexpr (Dimension > 1) {
-    return computeLengthSquared<Dimension, Dimension-1>(v);
-  }
-  else {
-    return v(0)*v(0);
+    return computeLengthSquared<Dimension, Dimension - 1>(v);
+  } else {
+    return v(0) * v(0);
   }
 }
-
-
-
 
 template <size_t Coordinate>
 inline double computeDistance(const size_t row, const size_t col,

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -12,7 +12,7 @@
 namespace mathtools {
 
 template <size_t Dimension, size_t Coordinate>
-inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
+constexpr inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   if constexpr (Coordinate == 0) {
     return v(0) * v(0);
   } else {
@@ -22,7 +22,7 @@ inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
 }
 
 template <size_t Dimension>
-inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
+constexpr inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   if constexpr (Dimension > 1) {
     return computeLengthSquared<Dimension, Dimension - 1>(v);
   } else {
@@ -32,7 +32,7 @@ inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
 
 ///@todo srowe: These need to be marked constexpr I think
 template <size_t Dimension, size_t Coordinate>
-inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
+constexpr inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
                                      const arma::rowvec::fixed<Dimension> &v2) {
 
   if constexpr (Coordinate == 0) {
@@ -45,7 +45,7 @@ inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
 }
 
 template <size_t Dimension>
-inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
+constexpr inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
                                      const arma::rowvec::fixed<Dimension> &v2) {
   if constexpr (Dimension > 1) {
     return computeSquaredDistance<Dimension, Dimension - 1>(v1, v2);

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -30,6 +30,30 @@ inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   }
 }
 
+///@todo srowe: These need to be marked constexpr I think
+template <size_t Dimension, size_t Coordinate>
+inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
+                                     const arma::rowvec::fixed<Dimension> &v2) {
+
+  if constexpr (Coordinate == 0) {
+    return (v1(0) - v2(0)) * (v1(0) - v2(0));
+  } else {
+    return (v1(Coordinate) - v2(Coordinate)) *
+               (v1(Coordinate) - v2(Coordinate)) +
+           computeSquaredDistance<Dimension, Coordinate - 1>(v1, v2);
+  }
+}
+
+template <size_t Dimension>
+inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
+                                     const arma::rowvec::fixed<Dimension> &v2) {
+  if constexpr (Dimension > 1) {
+    return computeSquaredDistance<Dimension, Dimension - 1>(v1, v2);
+  } else {
+    return (v1(0) - v2(0)) * (v1(0) - v2(0));
+  }
+}
+
 template <size_t Coordinate>
 inline double computeDistance(const size_t row, const size_t col,
                               const arma::mat &points) {

--- a/include/rbf/gaussian.h
+++ b/include/rbf/gaussian.h
@@ -6,7 +6,7 @@
 template <typename T> struct Gaussian {
   Gaussian(const T val) : ScaleParameter(val) {}
 
-  T operator()(const T r_squared) {
+  inline T operator()(const T r_squared) {
     return std::exp(-ScaleParameter * r_squared);
   }
 

--- a/include/rbf/interpolate.h
+++ b/include/rbf/interpolate.h
@@ -66,10 +66,6 @@ private:
     const double diagonal_value = kernel_(0.0);
 
     interpolation_matrix.diag().fill(diagonal_value);
-    for (size_t row = 0; row < num_centers; ++row) {
-      interpolation_matrix(row, row) =
-          diagonal_value; ///@todo srowe: Improve this
-    }
 
     // Solve linear system
     coefficients_ = arma::solve(interpolation_matrix, sampled_data);

--- a/include/rbf/interpolate.h
+++ b/include/rbf/interpolate.h
@@ -64,7 +64,8 @@ private:
     }
 
     const double diagonal_value = kernel_(0.0);
-    ;
+
+    interpolation_matrix.diag().fill(diagonal_value);
     for (size_t row = 0; row < num_centers; ++row) {
       interpolation_matrix(row, row) =
           diagonal_value; ///@todo srowe: Improve this
@@ -74,6 +75,7 @@ private:
     coefficients_ = arma::solve(interpolation_matrix, sampled_data);
 
     }
+
     Kernel kernel_;
     arma::mat centers_;
     arma::vec coefficients_;

--- a/include/rbf/thin_plate_spline.h
+++ b/include/rbf/thin_plate_spline.h
@@ -6,8 +6,8 @@
 struct ThinPlateSpline {
 
     // r represents distance between points squared
-    double operator()(const double dist_squared) {
-        return .5*dist_squared*std::log(dist_squared);
+    inline double operator()(const double dist_squared) {
+      return .5 * dist_squared * std::log(dist_squared);
     }
 
 };

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -2,6 +2,18 @@
 #include <gtest/gtest.h>
 #include <stdio.h>
 
+TEST(MathTest, TestComputeLength) {
+  arma::rowvec::fixed<3> v{1,2,3};
+  const auto length = mathtools::computeLengthSquared<3>(v);
+  EXPECT_DOUBLE_EQ(14, length);
+}
+
+TEST(MathTest, TestComputeLengthOneDim) {
+  arma::rowvec::fixed<1> v{-2};
+  const auto length = mathtools::computeLengthSquared<1>(v);
+  EXPECT_DOUBLE_EQ(4, length);
+}
+
 TEST(MathTest, ComputeDistance) {
 
   arma::mat points{{0, 1, 2}, {3, 4, 5}};
@@ -46,6 +58,8 @@ TEST(MathTest, LinspaceTest) {
   EXPECT_DOUBLE_EQ(a, points_odd[0]);
   EXPECT_DOUBLE_EQ(b, points_odd[num_points]);
 }
+
+
 
 TEST(MathTest, MeshgridTest) {
   double ax = 3;

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -1,9 +1,9 @@
-#include <math_utils/math_tools.h>
 #include <gtest/gtest.h>
+#include <math_utils/math_tools.h>
 #include <stdio.h>
 
 TEST(MathTest, TestComputeLength) {
-  arma::rowvec::fixed<3> v{1,2,3};
+  arma::rowvec::fixed<3> v{1, 2, 3};
   const auto length = mathtools::computeLengthSquared<3>(v);
   EXPECT_DOUBLE_EQ(14, length);
 }
@@ -58,8 +58,6 @@ TEST(MathTest, LinspaceTest) {
   EXPECT_DOUBLE_EQ(a, points_odd[0]);
   EXPECT_DOUBLE_EQ(b, points_odd[num_points]);
 }
-
-
 
 TEST(MathTest, MeshgridTest) {
   double ax = 3;

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -14,6 +14,14 @@ TEST(MathTest, TestComputeLengthOneDim) {
   EXPECT_DOUBLE_EQ(4, length);
 }
 
+TEST(MathTest, TestComputeSquaredDistance) {
+  arma::rowvec::fixed<3> v1{1, 2, 3};
+  arma::rowvec::fixed<3> v2{-3, -1, -2};
+
+  const auto squared_distance = mathtools::computeSquaredDistance<3>(v1, v2);
+  EXPECT_DOUBLE_EQ(4 * 4 + 3 * 3 + 5 * 5, squared_distance);
+}
+
 TEST(MathTest, ComputeDistance) {
 
   arma::mat points{{0, 1, 2}, {3, 4, 5}};


### PR DESCRIPTION
The purpose of this merge request is to clean up some of the interior code for constructing the interpolation matrix.

- [x] Replace for loop with .dag().fill(diagonal_value) to make it more "armadillo"-y