### PR TITLE
Add Computation of Full Lagrange Functions

### DIFF
--- a/include/lagrange/lagrange.h
+++ b/include/lagrange/lagrange.h
@@ -46,8 +46,12 @@ arma::mat computeLagrangeFunctions(const arma::mat &centers,
   arma::mat interpolation_matrix =
       computeInterpolationMatrix<Dimension, Kernel>(centers, kernel);
   const int num_points = centers.n_rows;
-  arma::mat coefficients =
-      arma::solve(interpolation_matrix, arma::eye(num_points, num_points));
+  arma::mat rhs = arma::eye(num_points + 3, num_points + 3);
+  // Zero out the diagonal for the polynomial terms.
+  rhs(num_points, num_points) = 0;
+  rhs(num_points + 1, num_points + 1) = 0;
+  rhs(num_points + 2, num_points + 2) = 0;
+  arma::mat coefficients = arma::solve(interpolation_matrix, rhs);
 
   return coefficients;
 }

--- a/include/lagrange/lagrange.h
+++ b/include/lagrange/lagrange.h
@@ -1,0 +1,55 @@
+#ifndef LOCAL_LAGRANGE_LAGRANGE_H
+#define LOCAL_LAGRANGE_LAGRANGE_H
+
+#include <armadillo>
+#include <array>
+#include <cmath>
+#include <math_utils/math_tools.h>
+#include <vector>
+
+namespace local_lagrange {
+
+template <size_t Dimension, typename Kernel>
+arma::mat computeInterpolationMatrix(const arma::mat &centers,
+                                     const Kernel &kernel) {
+  const size_t num_centers = centers.n_rows;
+
+  ///@todo srowe: The 3 is not super right
+  arma::mat interp_matrix(num_centers + 3, num_centers + 3, arma::fill::zeros);
+  double dist = 0.0;
+  for (size_t row = 0; row < num_centers; ++row) {
+    for (size_t col = row + 1; col < num_centers; ++col) {
+      dist = mathtools::computeDistance<Dimension - 1>(row, col, centers);
+
+      interp_matrix(row, col) = interp_matrix(col, row) = kernel(dist);
+    }
+  }
+
+  ///@todo srowe: We need to modify this for different dimensions
+  for (size_t row = 0; row < num_centers; ++row) {
+    interp_matrix(num_centers, row) = interp_matrix(row, num_centers) = 1;
+    interp_matrix(num_centers + 1, row) = interp_matrix(row, num_centers + 1) =
+        centers(row, 0);
+    interp_matrix(num_centers + 2, row) = interp_matrix(row, num_centers + 2) =
+        centers(row, 1);
+  }
+
+  return interp_matrix;
+}
+
+template <size_t Dimension, typename Kernel>
+arma::mat computeLagrangeFunctions(const arma::mat &centers,
+                                   const Kernel &kernel) {
+  // The Lagrange Functions are computed by forming a full distance matrix
+  // applying the kernel to it, and solving Ax = b where b is a diagonal matrix.
+
+  arma::mat interpolation_matrix =
+      computeInterpolationMatrix<Dimension, Kernel>(centers, kernel);
+  const int num_points = centers.n_rows;
+  arma::mat coefficients =
+      arma::solve(interpolation_matrix, arma::eye(num_points, num_points));
+
+  return coefficients;
+}
+} // namespace local_lagrange
+#endif // LOCAL_LAGRANGE_LAGRANGE_H

--- a/include/rbf/gaussian.h
+++ b/include/rbf/gaussian.h
@@ -6,11 +6,10 @@
 template <typename T> struct Gaussian {
   Gaussian(const T val) : ScaleParameter(val) {}
 
-  inline T operator()(const T r_squared) {
+  inline T operator()(const T r_squared) const {
     return std::exp(-ScaleParameter * r_squared);
   }
 
   T ScaleParameter;
 };
 #endif // LOCAL_LAGRANGE_GAUSSIAN_H
-

--- a/include/rbf/interpolate.h
+++ b/include/rbf/interpolate.h
@@ -41,11 +41,10 @@ public:
     }
 
     ///@todo srowe; If we're doing the sums above, we might as well just do the
-    ///matrix multiplication as well
-    return distance_matrix * coefficients_; 
+    /// matrix multiplication as well
+    return distance_matrix * coefficients_;
+  }
 
-    }
-    
 private:
   void buildCoefficients(const arma::vec &sampled_data) {
     // Build Interpolation Matrix
@@ -69,14 +68,12 @@ private:
 
     // Solve linear system
     coefficients_ = arma::solve(interpolation_matrix, sampled_data);
+  }
 
-    }
-
-    Kernel kernel_;
-    arma::mat centers_;
-    arma::vec coefficients_;
+  Kernel kernel_;
+  arma::mat centers_;
+  arma::vec coefficients_;
 };
 } // end namespace rbf
 
 #endif // LOCAL_LAGRANGE_INTERPOLATE_H
-

--- a/include/rbf/thin_plate_spline.h
+++ b/include/rbf/thin_plate_spline.h
@@ -5,12 +5,10 @@
 
 struct ThinPlateSpline {
 
-    // r represents distance between points squared
-    inline double operator()(const double dist_squared) {
-      return .5 * dist_squared * std::log(dist_squared);
-    }
-
+  // r represents distance between points squared
+  inline double operator()(const double dist_squared) const {
+    return .5 * dist_squared * std::log(dist_squared);
+  }
 };
 
 #endif
-

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(kdtree)
+add_subdirectory(lagrange_functions)
 add_subdirectory(local_lagrange)
 add_subdirectory(math_utils)
 add_subdirectory(radial_basis_functions)

--- a/src/lib/lagrange_functions/CMakeLists.txt
+++ b/src/lib/lagrange_functions/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tests)

--- a/src/lib/lagrange_functions/tests/CMakeLists.txt
+++ b/src/lib/lagrange_functions/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_executable(lagrange_functions_test test_lagrange_functions.cpp)
+target_link_libraries(lagrange_functions_test ${math_lib} ${ARMADILLO_LIBRARIES})
+
+add_test(NAME lagrange_functions_test COMMAND lagrange_functions_test)

--- a/src/lib/lagrange_functions/tests/test_lagrange_functions.cpp
+++ b/src/lib/lagrange_functions/tests/test_lagrange_functions.cpp
@@ -19,11 +19,24 @@ TEST_CASE("ComputeAllLagrangeFunctions") {
   const arma::mat coefficients =
       computeLagrangeFunctions<2, ThinPlateSpline>(centers, tps);
 
-  arma::mat expected = arma::eye(centers.n_rows, centers.n_rows);
+  // Coefficients in each col j satisfy
+  // \sum_i=1^n coefs(i,j)*\Phi(\|x_k - x_i) + Poly(x_k)  = \delta_{k,j}
 
-  const arma::mat result = coefficients * centers;
+  // Build Up Interpolation Matrix
 
-  const double error = arma::abs(result - expected).max();
+  const arma::mat interpolation_matrix =
+      computeInterpolationMatrix<2, ThinPlateSpline>(centers, tps);
+
+  const arma::mat result = interpolation_matrix * coefficients;
+
+  arma::mat expected = arma::eye(centers.n_rows + 3, centers.n_rows + 3);
+
+  const size_t n = centers.n_rows;
+  expected(n, n) = 0.0;
+  expected(n + 1, n + 1) = 0.0;
+  expected(n + 2, n + 2) = 0.0;
+
+  double error = arma::abs(expected - result).max();
 
   REQUIRE(error <= 1e-12);
 }

--- a/src/lib/lagrange_functions/tests/test_lagrange_functions.cpp
+++ b/src/lib/lagrange_functions/tests/test_lagrange_functions.cpp
@@ -1,0 +1,29 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <lagrange/lagrange.h>
+#include <rbf/thin_plate_spline.h>
+
+#include <math_utils/math_tools.h>
+
+using namespace local_lagrange;
+
+TEST_CASE("ComputeAllLagrangeFunctions") {
+  // Fundamentally, coefficients * centers = eye(n,n)
+  // We will test this on a small collection of points
+  const size_t num_points = 10;
+  const std::vector<double> xmesh =
+      mathtools::linspace<double>(0, 1, num_points);
+  const arma::mat centers = mathtools::meshgrid<double>(xmesh, xmesh);
+  const ThinPlateSpline tps;
+  const arma::mat coefficients =
+      computeLagrangeFunctions<2, ThinPlateSpline>(centers, tps);
+
+  arma::mat expected = arma::eye(centers.n_rows, centers.n_rows);
+
+  const arma::mat result = coefficients * centers;
+
+  const double error = arma::abs(result - expected).max();
+
+  REQUIRE(error <= 1e-12);
+}


### PR DESCRIPTION
This pull request adds an additional feature of computing full Lagrange functions for Thin Plate Splines. We note that this is not computationally efficient, but is provided as a helper function and as a useful study tool.

- [x] Full Lagrange Functions computed