### PR TITLE
Templatize on Kernel type for Local Lagrange Functions

### DIFF
--- a/include/local_lagrange/local_lagrange.h
+++ b/include/local_lagrange/local_lagrange.h
@@ -11,7 +11,7 @@
 
 namespace local_lagrange {
 
-template <size_t Dimension = 2, typename Kernel = ThinPlateSpline>
+template <size_t Dimension = 2, typename Kernel = ThinPlateSpline<Dimension>>
 class LocalLagrange {
 public:
   LocalLagrange(const arma::mat &local_centers, const unsigned int local_index)

--- a/include/local_lagrange/local_lagrange.h
+++ b/include/local_lagrange/local_lagrange.h
@@ -6,63 +6,37 @@
 #include <math_utils/math_tools.h>
 #include <vector>
 
+#include <lagrange/lagrange.h>
+#include <rbf/thin_plate_spline.h>
+
 namespace local_lagrange {
 
-template <size_t Dimension = 2> class LocalLagrange {
+template <size_t Dimension = 2, typename Kernel = ThinPlateSpline>
+class LocalLagrange {
 public:
-  LocalLagrange(const arma::mat &local_centers, const arma::uvec &local_indices,
-                const unsigned int local_index)
-      : index_(local_index), indices_(local_indices), centers_(local_centers) {
+  LocalLagrange(const arma::mat &local_centers, const unsigned int local_index)
+      : index_(local_index), centers_(local_centers) {
     buildCoefficients(centers_, index_);
   }
 
   explicit LocalLagrange(unsigned int index) : index_(index) {}
 
-  LocalLagrange(unsigned int index, const arma::uvec &indices,
-                const arma::vec &coefs)
-      : index_(index), indices_(indices), coefficients_(coefs) {}
-
-  arma::mat assembleInterpolationMatrix(const arma::mat &local_centers) {
-    // Initialize matrix to all zeros.
-
-    const size_t n_rows = local_centers.n_rows;
-    arma::mat interp_matrix(n_rows + 3, n_rows + 3, arma::fill::zeros);
-    double dist = 0.0;
-    size_t num_centers = local_centers.n_rows;
-    for (size_t row = 0; row < num_centers; ++row) {
-      for (size_t col = row + 1; col < num_centers; ++col) {
-        dist =
-            mathtools::computeDistance<Dimension - 1>(row, col, local_centers);
-
-        interp_matrix(row, col) = interp_matrix(col, row) =
-            .5 * dist * std::log(dist);
-      }
-    }
-
-    ///@todo srowe: We need to modify this for different dimensions
-    for (size_t row = 0; row < num_centers; ++row) {
-      interp_matrix(num_centers, row) = interp_matrix(row, num_centers) = 1;
-      interp_matrix(num_centers + 1, row) =
-          interp_matrix(row, num_centers + 1) = local_centers(row, 0);
-      interp_matrix(num_centers + 2, row) =
-          interp_matrix(row, num_centers + 2) = local_centers(row, 1);
-    }
-
-    return interp_matrix;
-  }
+  LocalLagrange(unsigned int index, const arma::vec &coefs)
+      : index_(index), coefficients_(coefs) {}
 
   void buildCoefficients(const arma::mat &local_centers,
                          unsigned int local_index) {
     // Work needed here perhaps. Is this bad generating interp_matrix in this
     // function?
-    const arma::mat interp_matrix = assembleInterpolationMatrix(local_centers);
+    Kernel kernel; ///@todo srowe: This is pretty derpy here
+    const arma::mat interp_matrix =
+        assembleInterpolationMatrix(local_centers, kernel);
     arma::vec rhs(local_centers.n_rows + 3, arma::fill::zeros);
     rhs(local_index) = 1;
     coefficients_ = arma::solve(interp_matrix, rhs);
   }
 
   unsigned int index() const { return index_; }
-  arma::uvec indices() const { return indices_; }
   arma::vec coefficients() const { return coefficients_; }
   arma::mat centers() const { return centers_; }
 
@@ -91,6 +65,7 @@ public:
         //.5 r^2 log(r^2) = r^2 log(r), this way we don't need square root
         ///@todo srowe: Would it be faster to convert this to std::log1p and use
         /// a conversion factor?
+        ///@todo srowe: REPLACE THIS WITH KERNEL!!!
         result += coefficients_(i) * distance * std::log(distance);
       }
     }
@@ -116,8 +91,8 @@ public:
 
 private:
   unsigned int index_;
-  arma::uvec indices_;
-  arma::mat centers_;
+  arma::mat centers_; ///@todo srowe: Each LLF maintaing its centers is probably
+                      ///overkill
   arma::vec coefficients_;
 };
 

--- a/include/local_lagrange/local_lagrange.h
+++ b/include/local_lagrange/local_lagrange.h
@@ -30,7 +30,7 @@ public:
     // function?
     Kernel kernel; ///@todo srowe: This is pretty derpy here
     const arma::mat interp_matrix =
-        assembleInterpolationMatrix(local_centers, kernel);
+        computeInterpolationMatrix<Dimension, Kernel>(local_centers, kernel);
     arma::vec rhs(local_centers.n_rows + 3, arma::fill::zeros);
     rhs(local_index) = 1;
     coefficients_ = arma::solve(interp_matrix, rhs);
@@ -39,8 +39,6 @@ public:
   unsigned int index() const { return index_; }
   arma::vec coefficients() const { return coefficients_; }
   arma::mat centers() const { return centers_; }
-
-  void setIndices(const arma::uvec &indices) { indices_ = indices; }
 
   // Evaluates the Local Lagrange Function at a collection of points
   // The LLF evaluates via \sum_{i=1}^N c_i \|p -x_i\|^2 log(\|p - x_i\|)
@@ -92,7 +90,7 @@ public:
 private:
   unsigned int index_;
   arma::mat centers_; ///@todo srowe: Each LLF maintaing its centers is probably
-                      ///overkill
+                      /// overkill
   arma::vec coefficients_;
 };
 

--- a/include/local_lagrange/local_lagrange_assembler.h
+++ b/include/local_lagrange/local_lagrange_assembler.h
@@ -12,7 +12,7 @@
 
 namespace local_lagrange {
 
-template <size_t Dimension = 2, typename Kernel = ThinPlateSpline>
+template <size_t Dimension = 2, typename Kernel = ThinPlateSpline<Dimension>>
 class LocalLagrangeAssembler {
 public:
   LocalLagrangeAssembler(const arma::mat &centers, const double radius)

--- a/include/local_lagrange/local_lagrange_assembler.h
+++ b/include/local_lagrange/local_lagrange_assembler.h
@@ -12,9 +12,9 @@
 
 namespace local_lagrange {
 
-template <size_t Dimension = 2> class LocalLagrangeAssembler {
+template <size_t Dimension = 2, typename Kernel = ThinPlateSpline>
+class LocalLagrangeAssembler {
 public:
-
   LocalLagrangeAssembler(const arma::mat &centers, const double radius)
       : centers_(centers), radius_(radius),
         kdtree_root_(BuildTree<Dimension>(centers_)) {}
@@ -56,10 +56,9 @@ public:
       local_centers.row(i) = row;
       ++i;
     }
-    const arma::uvec local_indices{
-        0}; // Dud, this needs to be eliminated! ///@todo srowe
+
     const size_t local_index = findLocalIndex(local_centers, index);
-    LocalLagrange<Dimension> llf(local_centers, local_indices, local_index);
+    LocalLagrange<Dimension, Kernel> llf(local_centers, local_index);
 
     return llf;
   }

--- a/include/local_lagrange/local_lagrange_interpolant.h
+++ b/include/local_lagrange/local_lagrange_interpolant.h
@@ -7,7 +7,8 @@
 namespace local_lagrange {
 // Provides ability to interpolate functions with a collection of Local Lagrange
 // Functions
-template <size_t Dimension> class LocalLagrangeEnsemble {
+template <size_t Dimension, typename Kernel = ThinPlateSpline>
+class LocalLagrangeEnsemble {
 public:
   LocalLagrangeEnsemble(const std::vector<LocalLagrange<Dimension>> &llfs)
       : m_llfs(llfs) {}
@@ -24,7 +25,7 @@ private:
       m_llfs; // Vector of Local Lagrange Functions
 };
 
-template <size_t Dimension>
+template <size_t Dimension, typename Kernel = ThinPlateSpline>
 LocalLagrangeEnsemble<Dimension>
 buildLocalLagrangeFunctions(const arma::mat &centers, const double radius) {
   // Instantiate a LocalLagrangeAssembler
@@ -42,7 +43,8 @@ buildLocalLagrangeFunctions(const arma::mat &centers, const double radius) {
   return LocalLagrangeEnsemble<Dimension>(llfs);
 }
 
-template <size_t Dimension> class LocalLagrangeInterpolant {
+template <size_t Dimension, typename Kernel = ThinPlateSpline>
+class LocalLagrangeInterpolant {
 public:
   LocalLagrangeInterpolant(const LocalLagrangeEnsemble<Dimension> &lle,
                            const arma::vec &sampled_function)
@@ -68,7 +70,7 @@ public:
   }
 
 private:
-  std::vector<LocalLagrange<Dimension>> m_llfs;
+  std::vector<LocalLagrange<Dimension, Kernel>> m_llfs;
   arma::vec m_sampled_function;
 };
 

--- a/include/local_lagrange/local_lagrange_interpolant.h
+++ b/include/local_lagrange/local_lagrange_interpolant.h
@@ -7,7 +7,7 @@
 namespace local_lagrange {
 // Provides ability to interpolate functions with a collection of Local Lagrange
 // Functions
-template <size_t Dimension, typename Kernel = ThinPlateSpline>
+template <size_t Dimension, typename Kernel = ThinPlateSpline<Dimension>>
 class LocalLagrangeEnsemble {
 public:
   LocalLagrangeEnsemble(const std::vector<LocalLagrange<Dimension>> &llfs)
@@ -25,7 +25,7 @@ private:
       m_llfs; // Vector of Local Lagrange Functions
 };
 
-template <size_t Dimension, typename Kernel = ThinPlateSpline>
+template <size_t Dimension, typename Kernel = ThinPlateSpline<Dimension>>
 LocalLagrangeEnsemble<Dimension>
 buildLocalLagrangeFunctions(const arma::mat &centers, const double radius) {
   // Instantiate a LocalLagrangeAssembler
@@ -43,7 +43,7 @@ buildLocalLagrangeFunctions(const arma::mat &centers, const double radius) {
   return LocalLagrangeEnsemble<Dimension>(llfs);
 }
 
-template <size_t Dimension, typename Kernel = ThinPlateSpline>
+template <size_t Dimension, typename Kernel = ThinPlateSpline<Dimension>>
 class LocalLagrangeInterpolant {
 public:
   LocalLagrangeInterpolant(const LocalLagrangeEnsemble<Dimension> &lle,

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -69,10 +69,15 @@ void applyPower(arma::mat& matrix, const arma::mat& points, const Tuple<Dimensio
   for (size_t i = 1; i < Dimension; ++i) {
     p %= arma::pow(points.col(i), powers[i]);
   }
-
+  
   const size_t num_points = points.n_rows;
-  matrix(arma::span(0,num_points), offset) = p;
-  matrix(offset, arma::span(0, num_points)) = p;
+  std::cout << "Applying to column offset\n";
+  p.print("P");
+  matrix.print("Matrix");
+  matrix(arma::span(0,num_points-1), offset) = p;
+    std::cout << "Applying to row offset\n";
+
+  matrix(offset, arma::span(0, num_points-1)) = p.t();
 }
 
 

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -35,12 +35,59 @@ void findtuples(std::vector<std::array<size_t, Dimension>>& results, size_t sumt
   
 }
 
+
+// Inefficient approach: Make a {0,1,...degree}^dimension cube and iterate through them all.
 template <size_t Dimension>
-void findtuples(std::vector<std::array<size_t, Dimension>>& results, size_t sumtotal, const size_t position) {
-    std::array<size_t, Dimension> array;
-    array.fill(0);
-    findtuples<Dimension>(results, sumtotal, position, array);
+using Tuple = std::array<int, Dimension>;
+
+template <size_t Dimension>
+int sum(const Tuple<Dimension>& t) {
+  int result = 0;
+  for (size_t i = 0 ; i < Dimension; ++i) {
+    result += t[i];
+  }
+  return result;
 }
+
+template <size_t Dimension, size_t current_dimension>
+void findtuples(const int degree, Tuple<Dimension> tuple, std::vector<Tuple<Dimension>>& results) {
+    // Recursively walk back
+
+
+    for (int i = 0; i < degree; ++i) {
+        // If we are in the last position, we are done, so test it
+        if constexpr (Dimension == (current_dimension-1)) {
+          tuple[current_dimension] = i;
+          if (sum(tuple) == degree) {
+            results.push_back(tuple);
+          }
+        }
+          else {
+          Tuple<Dimension> candidate = tuple; // copy the current result thats filled, and place an i in Dimension slot
+          candidate[current_dimension] = i; 
+
+          findtuples<Dimension, current_dimension +1>(degree, candidate, results);
+          }
+    }
+
+}
+
+
+
+template <size_t Dimension>
+std::vector<Tuple<Dimension>> findtuples(const int degree) {
+  std::vector<Tuple<Dimension>> results;
+  for (int i = 0; i < degree; ++i)
+  {
+      Tuple<Dimension> candidate;
+      candidate.fill(0);
+      candidate[0] = i;
+      findtuples<Dimension, 1>(degree, candidate, results);
+  }
+
+  return results;
+}
+
 
 constexpr size_t factorial(size_t n) {
   if (n == 0) {

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -11,8 +11,30 @@
 
 namespace mathtools {
 
+constexpr size_t factorial(size_t n) {
+  if (n == 0) {
+    return 1;
+  } else {
+    return n * factorial(n - 1);
+  }
+}
+
+/**
+ * @brief Computes the size of a polynomial basis of given degree in in
+ * Dimension variables
+ * @param[in] degree is the desired upper degree of the polynomials
+ *
+ * @return Returns the number of monomials needed to build the polynomial basis
+ */
+template <size_t Dimension>
+constexpr inline size_t computePolynomialBasis(const size_t degree) {
+  return factorial(Dimension + degree) /
+         (factorial(degree) * factorial(Dimension));
+}
+
 template <size_t Dimension, size_t Coordinate>
-constexpr inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
+constexpr inline double
+computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   if constexpr (Coordinate == 0) {
     return v(0) * v(0);
   } else {
@@ -22,7 +44,8 @@ constexpr inline double computeLengthSquared(const arma::rowvec::fixed<Dimension
 }
 
 template <size_t Dimension>
-constexpr inline double computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
+constexpr inline double
+computeLengthSquared(const arma::rowvec::fixed<Dimension> &v) {
   if constexpr (Dimension > 1) {
     return computeLengthSquared<Dimension, Dimension - 1>(v);
   } else {
@@ -32,8 +55,9 @@ constexpr inline double computeLengthSquared(const arma::rowvec::fixed<Dimension
 
 ///@todo srowe: These need to be marked constexpr I think
 template <size_t Dimension, size_t Coordinate>
-constexpr inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
-                                     const arma::rowvec::fixed<Dimension> &v2) {
+constexpr inline double
+computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
+                       const arma::rowvec::fixed<Dimension> &v2) {
 
   if constexpr (Coordinate == 0) {
     return (v1(0) - v2(0)) * (v1(0) - v2(0));
@@ -45,8 +69,9 @@ constexpr inline double computeSquaredDistance(const arma::rowvec::fixed<Dimensi
 }
 
 template <size_t Dimension>
-constexpr inline double computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
-                                     const arma::rowvec::fixed<Dimension> &v2) {
+constexpr inline double
+computeSquaredDistance(const arma::rowvec::fixed<Dimension> &v1,
+                       const arma::rowvec::fixed<Dimension> &v2) {
   if constexpr (Dimension > 1) {
     return computeSquaredDistance<Dimension, Dimension - 1>(v1, v2);
   } else {

--- a/include/math_utils/math_tools.h
+++ b/include/math_utils/math_tools.h
@@ -11,6 +11,37 @@
 
 namespace mathtools {
 
+
+ 
+template <size_t Dimension>
+void findtuples(std::vector<std::array<size_t, Dimension>>& results, size_t sumtotal, const size_t position,
+                                                      std::array<size_t, Dimension> currarray) {
+  if ((sumtotal == 0) || (position == Dimension)) {
+    return;
+  }
+
+  auto nextarray = currarray; // copy it for downstream use
+
+  currarray[position] = sumtotal; // e.g. 2
+  for (size_t pos = position; pos < Dimension; ++pos) {
+    currarray[pos] = 0;
+  }
+  results.push_back(currarray);
+
+  nextarray[position] = sumtotal -1;
+  findtuples(results, sumtotal - 1, position + 1, nextarray);
+
+  // Now decrement by 1, place it into that position, and move down
+  
+}
+
+template <size_t Dimension>
+void findtuples(std::vector<std::array<size_t, Dimension>>& results, size_t sumtotal, const size_t position) {
+    std::array<size_t, Dimension> array;
+    array.fill(0);
+    findtuples<Dimension>(results, sumtotal, position, array);
+}
+
 constexpr size_t factorial(size_t n) {
   if (n == 0) {
     return 1;

--- a/include/rbf/thin_plate_spline.h
+++ b/include/rbf/thin_plate_spline.h
@@ -2,7 +2,6 @@
 #define LOCAL_LAGRANGE_THIN_PLATE_SPLINE_H
 
 #include <armadillo>
-#include <math_tools.h>
 
 template <size_t Dimenion = 2, size_t Degree = 1>
 struct ThinPlateSpline {

--- a/include/rbf/thin_plate_spline.h
+++ b/include/rbf/thin_plate_spline.h
@@ -2,13 +2,47 @@
 #define LOCAL_LAGRANGE_THIN_PLATE_SPLINE_H
 
 #include <armadillo>
+#include <math_tools.h>
 
+template <size_t Dimension =2, size_t Degree =1>
+void buildPolynomialMatrix(arma::mat& interpolation_matrix, const arma::mat& points) const {
+    const num_rows = interpolation_matrix.n_rows;
+    const num_cols = interpolation_matrix.n_cols;
+    const num_points = points.n_rows;
+
+    const size_t num_polynomials = computePolynomialBasis(Degree);
+
+    // Interpolation matrix for conditionally positive definite kernel is of the form [A P; P^T 0]. 
+    // Our goal is to fill in the matrix P. This form depends on the degree and basis;
+    // The form of the matrix will in ascending order from lowest degree constant polynomial
+    // to highest degree
+
+    if (num_points + num_polynomials != num_points) {
+      throw std::runtime_error("The size of the interpolation matrix is not equal to the number of points plus number of polynomial terms");
+    }
+
+    interpolation_matrix(arma::span(0,num_points-1), num_points) = 1.0; 
+    for (size_t degree = 0; degree < Degree; ++degree) {
+        // Given dim, and deg, find all subsets (x_1,x_2...x_dim) sums to deg
+        // For degree we have x^i*y^degree-i
+        // xyz poly would be for degree 1: x y z
+        // For degree 2 we would have x^2 + xy + xz + y^2 + yz + z^2;
+        // For degree 3 we would have x^3 + x^2 y + x^2z + x
+        // (3,0,0), (2,1,0), (2,0,1), (1,2,0), (1,1,1), (0,3,0), (0,2,1), (0,1,2), (0,)
+        for ()      
+
+    }
+
+
+  }
+template <size_t Dimenion = 2, size_t Degree = 1>
 struct ThinPlateSpline {
 
   // r represents distance between points squared
   inline double operator()(const double dist_squared) const {
     return .5 * dist_squared * std::log(dist_squared);
   }
+
 };
 
 #endif

--- a/include/rbf/thin_plate_spline.h
+++ b/include/rbf/thin_plate_spline.h
@@ -4,37 +4,6 @@
 #include <armadillo>
 #include <math_tools.h>
 
-template <size_t Dimension =2, size_t Degree =1>
-void buildPolynomialMatrix(arma::mat& interpolation_matrix, const arma::mat& points) const {
-    const num_rows = interpolation_matrix.n_rows;
-    const num_cols = interpolation_matrix.n_cols;
-    const num_points = points.n_rows;
-
-    const size_t num_polynomials = computePolynomialBasis(Degree);
-
-    // Interpolation matrix for conditionally positive definite kernel is of the form [A P; P^T 0]. 
-    // Our goal is to fill in the matrix P. This form depends on the degree and basis;
-    // The form of the matrix will in ascending order from lowest degree constant polynomial
-    // to highest degree
-
-    if (num_points + num_polynomials != num_points) {
-      throw std::runtime_error("The size of the interpolation matrix is not equal to the number of points plus number of polynomial terms");
-    }
-
-    interpolation_matrix(arma::span(0,num_points-1), num_points) = 1.0; 
-    for (size_t degree = 0; degree < Degree; ++degree) {
-        // Given dim, and deg, find all subsets (x_1,x_2...x_dim) sums to deg
-        // For degree we have x^i*y^degree-i
-        // xyz poly would be for degree 1: x y z
-        // For degree 2 we would have x^2 + xy + xz + y^2 + yz + z^2;
-        // For degree 3 we would have x^3 + x^2 y + x^2z + x
-        // (3,0,0), (2,1,0), (2,0,1), (1,2,0), (1,1,1), (0,3,0), (0,2,1), (0,1,2), (0,)
-        for ()      
-
-    }
-
-
-  }
 template <size_t Dimenion = 2, size_t Degree = 1>
 struct ThinPlateSpline {
 

--- a/src/lib/lagrange_functions/tests/test_lagrange_functions.cpp
+++ b/src/lib/lagrange_functions/tests/test_lagrange_functions.cpp
@@ -15,9 +15,9 @@ TEST_CASE("ComputeAllLagrangeFunctions") {
   const std::vector<double> xmesh =
       mathtools::linspace<double>(0, 1, num_points);
   const arma::mat centers = mathtools::meshgrid<double>(xmesh, xmesh);
-  const ThinPlateSpline tps;
+  const ThinPlateSpline<2> tps;
   const arma::mat coefficients =
-      computeLagrangeFunctions<2, ThinPlateSpline>(centers, tps);
+      computeLagrangeFunctions<2, ThinPlateSpline<2>>(centers, tps);
 
   // Coefficients in each col j satisfy
   // \sum_i=1^n coefs(i,j)*\Phi(\|x_k - x_i) + Poly(x_k)  = \delta_{k,j}
@@ -25,7 +25,7 @@ TEST_CASE("ComputeAllLagrangeFunctions") {
   // Build Up Interpolation Matrix
 
   const arma::mat interpolation_matrix =
-      computeInterpolationMatrix<2, ThinPlateSpline>(centers, tps);
+      computeInterpolationMatrix<2, ThinPlateSpline<2>>(centers, tps);
 
   const arma::mat result = interpolation_matrix * coefficients;
 

--- a/src/lib/local_lagrange/test/lagrange_test.cpp
+++ b/src/lib/local_lagrange/test/lagrange_test.cpp
@@ -15,9 +15,9 @@ TEST_CASE("AssembleInterpolationMatrix") {
   arma::mat centers{{1, 0}, {2, 1}, {3, 2}};
 
   local_lagrange::LocalLagrange<2> llf(0); // Index 0.
-  ThinPlateSpline tps;
+  ThinPlateSpline<2> tps;
   arma::mat interp_matrix =
-      computeInterpolationMatrix<2, ThinPlateSpline>(centers, tps);
+      computeInterpolationMatrix<2, ThinPlateSpline<2>>(centers, tps);
   for (size_t i = 0; i < 6; i++) {
     REQUIRE(0.0 == interp_matrix(i, i));
   }
@@ -37,9 +37,9 @@ TEST_CASE("SolveForCoefficients") {
   llf.buildCoefficients(centers, 0);
   arma::vec coefs = llf.coefficients();
 
-  ThinPlateSpline tps;
+  ThinPlateSpline<2> tps;
   arma::mat interp_matrix =
-      computeInterpolationMatrix<2, ThinPlateSpline>(centers, tps);
+      computeInterpolationMatrix<2, ThinPlateSpline<2>>(centers, tps);
   arma::vec rhs = interp_matrix * coefs;
   REQUIRE(rhs(local_index) == Approx(1.0).margin(1e-13));
   rhs(local_index) = 0;

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -163,8 +163,8 @@ TEST_CASE("WriteVectorTest") {
 
 TEST_CASE("FindTuplesDim3Degree1") {
    // Expect (1,0,0), (0,1,0), (0,0,1)
-   std::vector<std::array<size_t, 3>> results;
-   findtuples<3>(results, 1,0);
+
+   auto results = findtuples<3>(1);
 
    std::cout << "The size of results is " << results.size() << "\n";
    for (auto& v: results) {

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -160,3 +160,20 @@ TEST_CASE("WriteVectorTest") {
     std::cout << *i << " " << std::endl;
   }
 }
+
+TEST_CASE("FindTuplesDim3Degree1") {
+   // Expect (1,0,0), (0,1,0), (0,0,1)
+   std::vector<std::array<size_t, 3>> results;
+   findtuples<3>(results, 1,0);
+
+   std::cout << "The size of results is " << results.size() << "\n";
+   for (auto& v: results) {
+     std::cout << v[0] << " , " << v[1] << " , " << v[2] << "\n";
+   }
+}
+
+TEST_CASE("FindtuplesDim3Degree2") {
+  // Expect (2,0,0), (1,1,0), (1,0,1), (0,2,0), (0,1,1), (0,2,0)
+
+
+}

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -161,6 +161,20 @@ TEST_CASE("WriteVectorTest") {
   }
 }
 
+template <size_t Dimension>
+bool compareTuples(const std::vector<Tuple<Dimension>>& t1, const std::vector<Tuple<Dimension>>& t2) {
+    if (t1.size() != t2.size()) {
+      return false;
+    }
+
+    bool success = true;
+    for (const auto& i : t1) {
+      // Check that i is in t2;
+      success &= std::find(t2.begin(), t2.end(), i);
+    }
+
+    return success;
+}
 TEST_CASE("FindTuplesDim3Degree1") {
    // Expect (1,0,0), (0,1,0), (0,0,1)
 
@@ -170,10 +184,46 @@ TEST_CASE("FindTuplesDim3Degree1") {
    for (auto& v: results) {
      std::cout << v[0] << " , " << v[1] << " , " << v[2] << "\n";
    }
+   Tuple<3> expected0 = {0,0,1};
+   Tuple<3> expected1 = {0, 1, 0};
+   Tuple<3> expected2 = {1, 0, 0};
+
+   std::vector<Tuple<3>> expected{expected0, expected1, expected2};
+   REQUIRE(expected == results);
+   REQUIRE(results.size() == 3); 
 }
 
 TEST_CASE("FindtuplesDim3Degree2") {
   // Expect (2,0,0), (1,1,0), (1,0,1), (0,2,0), (0,1,1), (0,2,0)
+   auto results = findtuples<3>(2);
+   std::vector<Tuple<3>> expected{ {0,0,2},{0, 1, 1},  {0, 2, 0},  {1,0,1}, {1,1,0},  {2, 0, 0}};
+   std::cout << "The size of results is " << results.size() << "\n";
+   for (auto& v: results) {
+     std::cout << v[0] << " , " << v[1] << " , " << v[2] << "\n";
+   }
+
+   REQUIRE(results.size() == expected.size());
+   REQUIRE(expected == results);
+
+}
+
+TEST_CASE("TestApplyPower") {
+  Tuple<3> tuple{1,2,3};
+
+  const arma::mat points{{2 , 2, 2}, {1, 1, 1}, { 1, 2, 3}, {2 ,3 , 1}};
+  int num_polys = 1;
+  arma::mat matrix = arma::zeros(4+num_polys, 4 + num_polys);
+  int offset = 4;
+  applyPower<3>(matrix, points, tuple, offset);
+  const arma::vec& x = points.col(0);
+  const arma::vec& y = points.col(1);
+  const arma::vec& z = points.col(2);
+  const arma::vec expected = x % y %y % z % z % z;
+  const arma::vec computed = matrix.col(4);
+
+  const double error = arma::abs(expected - computed).max();
+  REQUIRE(error <= 1e-8);
+
 
 
 }

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -219,11 +219,16 @@ TEST_CASE("TestApplyPower") {
   const arma::vec& y = points.col(1);
   const arma::vec& z = points.col(2);
   const arma::vec expected = x % y %y % z % z % z;
-  const arma::vec computed = matrix.col(4);
-
+  const arma::vec computed = matrix.col(4).rows(0,3);
+  const arma::vec computed_row = matrix.row(4).cols(0,3).t();
+  
   const double error = arma::abs(expected - computed).max();
   REQUIRE(error <= 1e-8);
 
+  const double row_error = arma::abs(expected - computed_row).max();
+  REQUIRE(error <= 1e-8);
+
+  matrix.print("Matrix");
 
 
 }

--- a/src/lib/math_utils/test/math_test.cpp
+++ b/src/lib/math_utils/test/math_test.cpp
@@ -3,6 +3,23 @@
 #include <math_utils/math_tools.h>
 #include <stdio.h>
 
+using namespace mathtools;
+TEST_CASE("FactorialTestZero") {
+  size_t n = 0;
+  REQUIRE(1 == factorial(n));
+}
+
+TEST_CASE("FactorialTestOne") { REQUIRE(1 == factorial(1)); }
+
+TEST_CASE("FactorialTestLarger") { REQUIRE(4 * 3 * 2 == factorial(4)); }
+
+TEST_CASE("PolynomialSize") {
+  size_t degree = 3;
+  // basis is 1  ,x ,y, x2, xy, y2, x3 ,x2y, xy2, y3
+  size_t size_poly_basis = computePolynomialBasis<2>(degree);
+  REQUIRE(10 == size_poly_basis);
+}
+
 TEST_CASE("TestComputeLength") {
   arma::rowvec::fixed<3> v{1, 2, 3};
   const auto length = mathtools::computeLengthSquared<3>(v);
@@ -20,10 +37,10 @@ TEST_CASE("TestComputeSquaredDistance") {
   arma::rowvec::fixed<3> v2{-3, -1, -2};
 
   const auto squared_distance = mathtools::computeSquaredDistance<3>(v1, v2);
-  REQUIRE(4 * 4 + 3 * 3 + 5 * 5== squared_distance);
+  REQUIRE(4 * 4 + 3 * 3 + 5 * 5 == squared_distance);
 }
 
-TEST_CASE( "ComputeDistanceRowVecs") {
+TEST_CASE("ComputeDistanceRowVecs") {
 
   arma::mat points{{0, 1, 2}, {3, 4, 5}};
 
@@ -35,7 +52,7 @@ TEST_CASE( "ComputeDistanceRowVecs") {
   REQUIRE(expected_dist == dist);
 }
 
-TEST_CASE( "ComputeDistance") {
+TEST_CASE("ComputeDistance") {
 
   arma::mat points{{0, 1, 2}, {3, 4, 5}};
 
@@ -44,7 +61,7 @@ TEST_CASE( "ComputeDistance") {
   double dist = mathtools::computeDistance<2>(row, col, points);
 
   double expected_dist = 3 * 3 + 3 * 3 + 3 * 3;
-  REQUIRE(expected_dist ==dist);
+  REQUIRE(expected_dist == dist);
 }
 
 TEST_CASE("ComputePointDistance") {
@@ -96,17 +113,17 @@ TEST_CASE("MeshgridTest") {
   auto yvals = pointset.col(1);
 
   size_t num_vals = (num_x + 1) * (num_y + 1);
-  REQUIRE(num_vals== xvals.n_rows);
-  REQUIRE(num_vals== yvals.n_rows);
+  REQUIRE(num_vals == xvals.n_rows);
+  REQUIRE(num_vals == yvals.n_rows);
 
-  REQUIRE(xvals[0]== ax);
-  REQUIRE(xvals[num_vals - 1]== bx);
-  REQUIRE(xvals[3]== 3.25);
-  REQUIRE(xvals[num_vals - 4]== 3.75);
-  REQUIRE(yvals[0]== ay);
-  REQUIRE(yvals[num_vals - 1]== by);
-  REQUIRE(yvals[3]== 1);
-  REQUIRE(yvals[num_vals - 4]== 2);
+  REQUIRE(xvals[0] == ax);
+  REQUIRE(xvals[num_vals - 1] == bx);
+  REQUIRE(xvals[3] == 3.25);
+  REQUIRE(xvals[num_vals - 4] == 3.75);
+  REQUIRE(yvals[0] == ay);
+  REQUIRE(yvals[num_vals - 1] == by);
+  REQUIRE(yvals[3] == 1);
+  REQUIRE(yvals[num_vals - 4] == 2);
 }
 
 TEST_CASE("WriteVectorTest") {
@@ -118,9 +135,9 @@ TEST_CASE("WriteVectorTest") {
   while (infile >> read_value) {
     read_double_vec.push_back(read_value);
   }
-  REQUIRE(double_vec.size()== read_double_vec.size());
+  REQUIRE(double_vec.size() == read_double_vec.size());
   for (size_t iter = 0; iter < double_vec.size(); iter++) {
-    REQUIRE(double_vec[iter]== read_double_vec[iter]);
+    REQUIRE(double_vec[iter] == read_double_vec[iter]);
   }
   for (auto i = read_double_vec.begin(); i != read_double_vec.end(); ++i) {
     std::cout << *i << " " << std::endl;
@@ -135,13 +152,11 @@ TEST_CASE("WriteVectorTest") {
   while (std::getline(infile_string, read_string)) {
     read_string_vec.push_back(read_string);
   }
-  REQUIRE(string_vec.size()== read_string_vec.size());
+  REQUIRE(string_vec.size() == read_string_vec.size());
   for (size_t iter = 0; iter < string_vec.size(); iter++) {
-    REQUIRE(string_vec[iter]== read_string_vec[iter]);
+    REQUIRE(string_vec[iter] == read_string_vec[iter]);
   }
   for (auto i = read_string_vec.begin(); i != read_string_vec.end(); ++i) {
     std::cout << *i << " " << std::endl;
   }
 }
-
-


### PR DESCRIPTION
- [x] LLFs now have a Kernel template parameter
- [x] Common structure of computeInterpolationMatrix rather than repeated code
- [x] Remove dud Kernels
- [x] Fix @todo's related to the move
- [x] Kernels that are positive semi definite compute the size of the polynomial basis. Probably not fully functional in this pull request, but a step forward to more generic code